### PR TITLE
Add Over Request Prevention

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Check out my website at [markTakatsuka.com](https://markTakatsuka.com)
 | Mod (remainder)   | a % b | Modulo |
 | Absolute Value    | abs( a ) | Absolute Value |
 
-
-
-## Compile Protos
-```sh
-mvn clean install
-```
-
 ## Tech-Stack
 - Springboot
 - Java 11
+
+## Run on Compute Engine
+```shell
+gradle clean build
+
+gsutil cp build/libs/* gs://website-backend-builds/build[version].jar
+```

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-java:3.12.4'
     implementation 'com.google.protobuf:protobuf-java-util:3.12.4'
     implementation 'org.reflections:reflections:0.9.12'
+    implementation 'com.github.vladimir-bukhtoyarov:bucket4j-core:4.10.0'
     runtimeOnly 'org.springframework.boot:spring-boot-devtools:2.2.6.RELEASE'
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.2.6.RELEASE'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 }
 
 group = 'com.takatsuka'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.1'
 description = 'web'
 sourceCompatibility = '11'
 

--- a/src/main/java/com/takatsuka/web/math/MathController.java
+++ b/src/main/java/com/takatsuka/web/math/MathController.java
@@ -1,23 +1,56 @@
 package com.takatsuka.web.math;
 
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Bucket4j;
+import io.github.bucket4j.Refill;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
+import java.time.Duration;
+import java.util.HashMap;
+
 @RestController
 @CrossOrigin
 public class MathController {
 
-    private MathService mathService;
-    private final String BASE_URL = "/math/";
+  private final MathService mathService;
+  private final String BASE_URL = "/math/";
+  private static final HashMap<String, Bucket> BUCKETS = new HashMap<>();
+  private static final String REQUEST_OVERLOAD_MSG =
+      "You're making requests too quickly! Wait a little before making another.";
 
-    public MathController(MathService mathService) {
-        this.mathService = mathService;
-    }
+  // Refill one request every 6 seconds.
+  private static final Bandwidth BUCKET_BANDWIDTH =
+      Bandwidth.classic(1, Refill.intervally(1L, Duration.ofSeconds(6L)));
 
-    @GetMapping(BASE_URL + "evaluate")
-    public String evaluate(@RequestParam(name = "expression") String expression) {
-        return mathService.evaluateExpression(expression);
+  public MathController(MathService mathService) {
+    this.mathService = mathService;
+  }
+
+  @GetMapping(BASE_URL + "evaluate")
+  public String evaluate(
+      @RequestParam(name = "expression") String expression, HttpServletRequest request) {
+    Bucket bucket = getBucketOrCreate(request.getRemoteAddr());
+
+    if (bucket.tryConsume(1L)) {
+      return mathService.evaluateExpression(expression);
+    } else {
+      return REQUEST_OVERLOAD_MSG;
     }
+  }
+
+  private Bucket getBucketOrCreate(String address) {
+    Bucket bucket;
+    if (BUCKETS.containsKey(address)) {
+      bucket = BUCKETS.get(address);
+    } else {
+      bucket = Bucket4j.builder().addLimit(BUCKET_BANDWIDTH).build();
+      BUCKETS.put(address, bucket);
+    }
+    return bucket;
+  }
 }

--- a/src/main/java/com/takatsuka/web/math/MathService.java
+++ b/src/main/java/com/takatsuka/web/math/MathService.java
@@ -59,7 +59,7 @@ public class MathService {
     return result;
   }
 
-  public class DoEval implements Callable<String> {
+  private class DoEval implements Callable<String> {
     private final String expression;
 
     public DoEval(String expression) {

--- a/src/main/java/com/takatsuka/web/math/interpreter/FunctionMapper.java
+++ b/src/main/java/com/takatsuka/web/math/interpreter/FunctionMapper.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
 
 public class FunctionMapper {
   private static final String SYMBOL_GROUPS = "([+\\-*/%^!()])";
-  private static final String NUM_REGEX = "(-?\\d+(.\\d+)?)";
+  private static final String NUM_REGEX = "(-?\\d+([.]\\d+)?)";
 
   private final Map<String, Function> multiVariableFunctionMap;
   private final Map<String, Function> symbolOperatorMap;

--- a/src/main/java/com/takatsuka/web/math/interpreter/MathParser.java
+++ b/src/main/java/com/takatsuka/web/math/interpreter/MathParser.java
@@ -7,6 +7,7 @@ import com.takatsuka.web.logging.MathLogger;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -14,8 +15,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
+import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class MathParser {
   private static final Logger logger = MathLogger.forCallingClass();
@@ -362,4 +365,11 @@ public class MathParser {
 
     return builder;
   }
+
+//  private String padNumbers(String expression) {
+//    boolean prevIsNum = false;
+//    for (String tok: expression.split("")) {
+//        if()
+//    }
+//  }
 }

--- a/src/test/java/com/takatsuka/web/math/interpreter/MathParserTest.java
+++ b/src/test/java/com/takatsuka/web/math/interpreter/MathParserTest.java
@@ -89,6 +89,15 @@ public class MathParserTest {
   }
 
   @Test
+  public void testTokenize_noSpace() {
+    List<String> expectedTokens = List.of("1", "+", "2");
+
+    List<String> fetchedTokens = mathParser.tokenize("1+2");
+
+    Truth.assertThat(fetchedTokens).containsExactlyElementsIn(expectedTokens);
+  }
+
+  @Test
   public void testLoadTokensIntoTables_simpleExpression() {
     List<String> testTokens = mathParser.tokenize(SIMPLE_EXPRESSION);
     Map<Integer, ExpressionEntry> expectedMap =


### PR DESCRIPTION
**Major Changes**
In order to protect our backend, if we are getting too many requests from the same IP, this will prevent requests.

It is currently set to have a bucket / ip which has a capacity of 1, and refills 1 requests every 6 seconds. This is liable to be changed in the future, to allow for more initial requests (like 5) but have the same refill rate. This way, with a refill of 6 seconds and execution max time of 5 seconds, users cannot put the system at 100% load individually.

**Bug Fixes**
Additionally, this PR fixes the bug where "1+1" is interpreted as the token "1+1" instead of the tokens "1", "+", "1". This was due to a "." wildcard being used instead of the literal character in the number parsing regex.