### PR TITLE
Temporarily - Fix exec timeout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     testImplementation 'com.google.truth:truth:1.0.1'
     testImplementation 'com.google.truth.extensions:truth-proto-extension:1.1'
     compile group: 'io.grpc', name: 'grpc-all', version: '1.25.0'
+    compile "io.github.resilience4j:resilience4j-timelimiter:1.6.1"
 }
 
 group = 'com.takatsuka'

--- a/src/main/java/com/takatsuka/web/math/MathService.java
+++ b/src/main/java/com/takatsuka/web/math/MathService.java
@@ -6,12 +6,17 @@ import com.takatsuka.web.logging.MathLogger;
 import com.takatsuka.web.math.interpreter.FunctionMapper;
 import com.takatsuka.web.math.interpreter.MathParser;
 import com.takatsuka.web.math.interpreter.FunctionLoader;
+import io.github.resilience4j.timelimiter.TimeLimiter;
+import io.github.resilience4j.timelimiter.TimeLimiterConfig;
+import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Service;
 
 import java.math.MathContext;
+import java.time.Duration;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -22,9 +27,11 @@ import java.util.concurrent.TimeoutException;
 public class MathService {
   private static final Logger logger = MathLogger.forCallingClass();
   private static final int EXEC_TIME_LIMIT = 2; // Time in seconds to allow execution
+  private static final TimeLimiterConfig TIME_LIMITER_CONFIG = generateTimeLimiterConfig();
 
   private final MathParser mathParser;
   private final ExecutorService executorService;
+  private final TimeLimiterRegistry timeLimiterRegistry;
 
   private int precision = 10;
 
@@ -32,18 +39,19 @@ public class MathService {
     FunctionMapper functionMapper = new FunctionMapper(functionLoader.loadFunctions());
     this.mathParser = new MathParser(functionMapper);
     this.executorService = Executors.newCachedThreadPool();
+    this.timeLimiterRegistry = TimeLimiterRegistry.of(TIME_LIMITER_CONFIG);
   }
 
   public String evaluateExpression(String expression) {
     logger.info("Evaluating expression '{}'", expression);
     String result = "";
     Stopwatch stopwatch = Stopwatch.createStarted();
+    TimeLimiter timeLimiter = timeLimiterRegistry.timeLimiter("testTimeLimiter");
 
-    Future<String> future = executorService.submit(() -> mathParser.evaluate(expression));
     try {
-      result = future.get(EXEC_TIME_LIMIT, TimeUnit.SECONDS);
+      result = timeLimiter.executeFutureSupplier(
+          () -> CompletableFuture.supplyAsync(() -> mathParser.evaluate(expression)));
     } catch (TimeoutException e) {
-      future.cancel(true);
       logger.error("The Executor timed out.");
       result = String.format("The execution time limit (%s seconds) was reached.", EXEC_TIME_LIMIT);
     } catch (Exception e) {
@@ -60,18 +68,6 @@ public class MathService {
     return result;
   }
 
-  private class DoEval implements Callable<String> {
-    private final String expression;
-
-    public DoEval(String expression) {
-      this.expression = expression;
-    }
-
-    public String call() {
-      return mathParser.evaluate(expression);
-    }
-  }
-
   public void setPrecision(int newPrecision) {
     precision = newPrecision;
   }
@@ -83,5 +79,12 @@ public class MathService {
   @Bean
   public MathContext generateMathContext() {
     return new MathContext(precision);
+  }
+
+  private static TimeLimiterConfig generateTimeLimiterConfig() {
+    return TimeLimiterConfig.custom()
+        .cancelRunningFuture(/* cancelRunningFuture=*/ true)
+        .timeoutDuration(Duration.ofSeconds(EXEC_TIME_LIMIT))
+        .build();
   }
 }

--- a/src/main/java/com/takatsuka/web/math/interpreter/Evaluator.java
+++ b/src/main/java/com/takatsuka/web/math/interpreter/Evaluator.java
@@ -69,7 +69,11 @@ public class Evaluator {
       case MOD:
         return String.valueOf(new BigInteger(args.get(0)).mod(new BigInteger(args.get(1))));
       case POWER:
-        return String.valueOf(new BigInteger(args.get(0)).pow(Integer.parseInt(args.get(1))));
+        int exponent = Integer.parseInt(args.get(1));
+        if(exponent > 1024) {
+          throw new RuntimeException("Exponent too large!");
+        }
+        return String.valueOf(new BigInteger(args.get(0)).pow(exponent));
       case FACTORIAL:
         return String.valueOf(BigIntegerMath.factorial(Integer.parseInt(args.get(0))));
       case INT_DIVIDE:

--- a/src/main/java/com/takatsuka/web/math/interpreter/Evaluator.java
+++ b/src/main/java/com/takatsuka/web/math/interpreter/Evaluator.java
@@ -70,10 +70,11 @@ public class Evaluator {
         return String.valueOf(new BigInteger(args.get(0)).mod(new BigInteger(args.get(1))));
       case POWER:
         int exponent = Integer.parseInt(args.get(1));
+        int base = Integer.parseInt(args.get(0));
         if(exponent > 1024) {
           throw new RuntimeException("Exponent too large!");
         }
-        return String.valueOf(new BigInteger(args.get(0)).pow(exponent));
+        return String.valueOf(new BigInteger(String.valueOf(exponent)).pow(exponent));
       case FACTORIAL:
         return String.valueOf(BigIntegerMath.factorial(Integer.parseInt(args.get(0))));
       case INT_DIVIDE:

--- a/src/main/java/com/takatsuka/web/math/interpreter/Evaluator.java
+++ b/src/main/java/com/takatsuka/web/math/interpreter/Evaluator.java
@@ -74,7 +74,7 @@ public class Evaluator {
         if(exponent > 1024) {
           throw new RuntimeException("Exponent too large!");
         }
-        return String.valueOf(new BigInteger(String.valueOf(exponent)).pow(exponent));
+        return String.valueOf(new BigInteger(String.valueOf(base)).pow(exponent));
       case FACTORIAL:
         return String.valueOf(BigIntegerMath.factorial(Integer.parseInt(args.get(0))));
       case INT_DIVIDE:


### PR DESCRIPTION
This is a temporary fix for issue #34 (more like putting a bandaid on a bigger problem)

The problem that that issue is trying to solve, is that when a task is executed, it should:
1. Timeout, and send a timeout result to clients
2. Cancel the execution of the task.

The latter is much harder to solve. Testing was performed with BigInteger.pow, which cannot be interrupted (or it doesn't appear as such). So, methods will need to be implemented to handle the interrupt in the future, even base methods like POW. 

For the time being, functionality is implemented to timeout functions which will be interrupted, and a basic size limit is imposed on POW, but there is potential for further improvement.