### PR TITLE
Add Error Messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ target/
 !**/src/main/**
 !**/src/test/**
 src/main/resources/keystore/
-src/main/resources/application.properties
+src/main/resources/application*.properties
+
 
 ### STS ###
 .apt_generated

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ target/
 !**/src/main/**
 !**/src/test/**
 src/main/resources/keystore/
-src/main/resources/application*.properties
+application*.properties
 
 
 ### STS ###

--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ gradle clean build
 
 gsutil cp build/libs/* gs://website-backend-builds/[version].jar
 ```
+
+## Updating Certs
+```shell
+sudo certbot renew
+
+cd /etc/letsencrypt/live/[cert_name]
+openssl pkcs12 -export -in fullchain.pem -inkey privkey.pem -out keystore.p12 -name backend -CAfile chain.pem -caname root
+```

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 }
 
 group = 'com.takatsuka'
-version = '0.0.4'
+version = '0.0.5'
 description = 'web'
 sourceCompatibility = '11'
 

--- a/instance-startup.sh
+++ b/instance-startup.sh
@@ -20,4 +20,5 @@ apt-get -y --force-yes install openjdk-11-jdk
 update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/jre/bin/java
 
 # Start server
+export spring_profiles_active=prod
 java -jar /website-backend-builds/"${JARFILE}"

--- a/src/main/java/com/takatsuka/web/HomeController.java
+++ b/src/main/java/com/takatsuka/web/HomeController.java
@@ -7,10 +7,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @CrossOrigin
 public class HomeController {
-//    @GetMapping("/")
-//    public String home(){
-//        return "Hello from Spring Boot";
-//    }
     @GetMapping("/isUp")
     public String isUp() {
         return "Yes!";

--- a/src/main/java/com/takatsuka/web/math/MathService.java
+++ b/src/main/java/com/takatsuka/web/math/MathService.java
@@ -28,7 +28,6 @@ public class MathService {
   private static final Duration EXEC_TIME_LIMIT = Duration.ofSeconds(5); // Time in seconds to allow execution
 
   private final MathParser mathParser;
-  private final ExecutorService executorService;
   private final TimeLimiter timeLimiter;
 
   private int precision = 10;
@@ -36,7 +35,7 @@ public class MathService {
   MathService(FunctionLoader functionLoader) {
     FunctionMapper functionMapper = new FunctionMapper(functionLoader.loadFunctions());
     this.mathParser = new MathParser(functionMapper);
-    this.executorService = Executors.newCachedThreadPool();
+    ExecutorService executorService = Executors.newCachedThreadPool();
     this.timeLimiter = SimpleTimeLimiter.create(executorService);
   }
 

--- a/src/main/java/com/takatsuka/web/math/MathService.java
+++ b/src/main/java/com/takatsuka/web/math/MathService.java
@@ -3,6 +3,7 @@ package com.takatsuka.web.math;
 import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.SimpleTimeLimiter;
 import com.google.common.util.concurrent.TimeLimiter;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.takatsuka.web.logging.MathLogger;
 import com.takatsuka.web.math.interpreter.FunctionMapper;
 import com.takatsuka.web.math.interpreter.MathParser;
@@ -50,7 +51,14 @@ public class MathService {
     } catch(MathException exception){
       logger.error(exception.toString());
       result = exception.toString();
-    } catch (TimeoutException | InterruptedException | ExecutionException e) {
+    } catch(UncheckedExecutionException exception) {
+      // TODO: Figure out why this exection is being thrown.
+      //  This is a terrible way to check
+      if(exception.getCause() instanceof MathException){
+        logger.error("Unchecked Exception: " + exception.getCause());
+        result = exception.getCause().toString();
+      }
+    } catch(TimeoutException | InterruptedException | ExecutionException e) {
       logger.error("The Executor timed out.");
       result = String.format("The execution time limit (%s seconds) was reached.", EXEC_TIME_LIMIT);
     }

--- a/src/main/java/com/takatsuka/web/math/MathService.java
+++ b/src/main/java/com/takatsuka/web/math/MathService.java
@@ -7,6 +7,7 @@ import com.takatsuka.web.logging.MathLogger;
 import com.takatsuka.web.math.interpreter.FunctionMapper;
 import com.takatsuka.web.math.interpreter.MathParser;
 import com.takatsuka.web.math.interpreter.FunctionLoader;
+import com.takatsuka.web.utils.exceptions.MathException;
 import com.takatsuka.web.utils.exceptions.MathExecException;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Bean;
@@ -46,9 +47,9 @@ public class MathService {
     try {
       DoEval doEval = new DoEval(expression);
       result = timeLimiter.callWithTimeout(doEval, EXEC_TIME_LIMIT);
-    } catch(MathExecException execException){
-      logger.error(execException.toString());
-      result = execException.toString();
+    } catch(MathException exception){
+      logger.error(exception.toString());
+      result = exception.toString();
     } catch (TimeoutException | InterruptedException | ExecutionException e) {
       logger.error("The Executor timed out.");
       result = String.format("The execution time limit (%s seconds) was reached.", EXEC_TIME_LIMIT);

--- a/src/main/java/com/takatsuka/web/math/evaluators/ExponentialEvaluator.java
+++ b/src/main/java/com/takatsuka/web/math/evaluators/ExponentialEvaluator.java
@@ -45,7 +45,6 @@ public class ExponentialEvaluator {
         "modulus of modPow", null, MathExecException.MathExecExceptionType.POSITIVE_REQUIRED);
   }
 
-  // TODO(mark): Could use an optional on the mod.
   private String modPowHelper(BigDecimal base, BigInteger exp, Optional<BigInteger> optionalMod) {
     boolean ignoreMod = optionalMod.isEmpty();
     boolean isNegative = false;

--- a/src/main/java/com/takatsuka/web/math/evaluators/ExponentialEvaluator.java
+++ b/src/main/java/com/takatsuka/web/math/evaluators/ExponentialEvaluator.java
@@ -30,18 +30,19 @@ public class ExponentialEvaluator {
     return "Needs implementation.";
   }
 
-  public String pow(BigInteger base, BigInteger exp) {
+  public String pow(BigDecimal base, BigInteger exp) {
     return modPowHelper(base, exp, null, true);
   }
 
-  public String modPow(BigInteger base, BigInteger exp, BigInteger mod) {
+  public String modPow(BigDecimal base, BigInteger exp, BigInteger mod) {
     if(mod.signum() > 0) {
       return modPowHelper(base, exp, mod, false);
     }
     return "0"; // TODO(mark): notify that the sign of the mod was incorrect.
   }
 
-  private String modPowHelper(BigInteger base, BigInteger exp, BigInteger mod, boolean ignoreMod) {
+  // TODO(mark): Could use an optional on the mod.
+  private String modPowHelper(BigDecimal base, BigInteger exp, BigInteger mod, boolean ignoreMod) {
     boolean isNegative = false;
     // DO MATH
     if (exp.signum() < 0) {
@@ -49,7 +50,11 @@ public class ExponentialEvaluator {
       exp = exp.abs();
     }
 
-    BigInteger accumulator = BigInteger.ONE;
+    BigDecimal accumulator = BigDecimal.ONE;
+    BigDecimal decimal_mod = BigDecimal.ZERO; // Temporary
+    if (!ignoreMod) {
+      decimal_mod = new BigDecimal(mod);
+    }
 
     while (exp.signum() > 0) {
       ThreadUtils.throwIfInterrupted(logger); // Catch for interrupted thread.
@@ -61,15 +66,15 @@ public class ExponentialEvaluator {
       exp = exp.shiftRight(1);
 
       if(!ignoreMod) {
-        accumulator = accumulator.mod(mod);
-        base = base.mod(mod);
+        accumulator = accumulator.remainder(decimal_mod);
+        base = base.remainder(decimal_mod);
       }
     }
 
     String result = accumulator.toString();
 
     if(isNegative) {
-      result = BigDecimal.ONE.divide(new BigDecimal(accumulator), mathContext).toString();
+      result = BigDecimal.ONE.divide(accumulator, mathContext).toString();
     }
 
     return result;

--- a/src/main/java/com/takatsuka/web/math/evaluators/ExponentialEvaluator.java
+++ b/src/main/java/com/takatsuka/web/math/evaluators/ExponentialEvaluator.java
@@ -2,11 +2,13 @@ package com.takatsuka.web.math.evaluators;
 
 import com.takatsuka.web.logging.MathLogger;
 import com.takatsuka.web.utils.ThreadUtils;
+import com.takatsuka.web.utils.exceptions.MathExecException;
 import org.slf4j.Logger;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
+import java.util.Optional;
 
 public class ExponentialEvaluator {
 
@@ -18,7 +20,7 @@ public class ExponentialEvaluator {
     this.mathContext = mathContext;
   }
 
-  public String lg(BigDecimal input){
+  public String lg(BigDecimal input) {
     return logn(TWO, input);
   }
 
@@ -27,22 +29,25 @@ public class ExponentialEvaluator {
   }
 
   public String logn(BigDecimal base, BigDecimal value) {
-    return "Needs implementation.";
+    throw new MathExecException(
+        "logn", null, MathExecException.MathExecExceptionType.FUNCTION_IN_TESTING);
   }
 
   public String pow(BigDecimal base, BigInteger exp) {
-    return modPowHelper(base, exp, null, true);
+    return modPowHelper(base, exp, Optional.empty());
   }
 
   public String modPow(BigDecimal base, BigInteger exp, BigInteger mod) {
-    if(mod.signum() > 0) {
-      return modPowHelper(base, exp, mod, false);
+    if (mod.signum() > 0) {
+      return modPowHelper(base, exp, Optional.of(mod));
     }
-    return "0"; // TODO(mark): notify that the sign of the mod was incorrect.
+    throw new MathExecException(
+        "modulus of modPow", null, MathExecException.MathExecExceptionType.POSITIVE_REQUIRED);
   }
 
   // TODO(mark): Could use an optional on the mod.
-  private String modPowHelper(BigDecimal base, BigInteger exp, BigInteger mod, boolean ignoreMod) {
+  private String modPowHelper(BigDecimal base, BigInteger exp, Optional<BigInteger> optionalMod) {
+    boolean ignoreMod = optionalMod.isEmpty();
     boolean isNegative = false;
     // DO MATH
     if (exp.signum() < 0) {
@@ -53,7 +58,7 @@ public class ExponentialEvaluator {
     BigDecimal accumulator = BigDecimal.ONE;
     BigDecimal decimal_mod = BigDecimal.ZERO; // Temporary
     if (!ignoreMod) {
-      decimal_mod = new BigDecimal(mod);
+      decimal_mod = new BigDecimal(optionalMod.get());
     }
 
     while (exp.signum() > 0) {
@@ -65,7 +70,7 @@ public class ExponentialEvaluator {
       base = base.multiply(base);
       exp = exp.shiftRight(1);
 
-      if(!ignoreMod) {
+      if (!ignoreMod) {
         accumulator = accumulator.remainder(decimal_mod);
         base = base.remainder(decimal_mod);
       }
@@ -73,7 +78,7 @@ public class ExponentialEvaluator {
 
     String result = accumulator.toString();
 
-    if(isNegative) {
+    if (isNegative) {
       result = BigDecimal.ONE.divide(accumulator, mathContext).toString();
     }
 

--- a/src/main/java/com/takatsuka/web/math/interpreter/Evaluator.java
+++ b/src/main/java/com/takatsuka/web/math/interpreter/Evaluator.java
@@ -77,7 +77,7 @@ public class Evaluator {
       case MOD:
         return String.valueOf(new BigInteger(args.get(0)).mod(new BigInteger(args.get(1))));
       case POWER:
-        return exponentialEvaluator.pow(new BigInteger(args.get(0)), new BigInteger(args.get(1)));
+        return exponentialEvaluator.pow(new BigDecimal(args.get(0)), new BigInteger(args.get(1)));
       case FACTORIAL:
         return String.valueOf(BigIntegerMath.factorial(Integer.parseInt(args.get(0))));
       case INT_DIVIDE:

--- a/src/main/java/com/takatsuka/web/math/interpreter/Evaluator.java
+++ b/src/main/java/com/takatsuka/web/math/interpreter/Evaluator.java
@@ -70,7 +70,7 @@ public class Evaluator {
         if (param2.equals(BigDecimal.ZERO)) {
           throw new MathExecException(
               String.format("%s / %s", param1.toString(), param2.toString()),
-              0,
+              null,
               MathExecException.MathExecExceptionType.DIV_BY_ZERO);
         }
         return String.valueOf(param1.divide(param2, mathContext));

--- a/src/main/java/com/takatsuka/web/math/interpreter/Evaluator.java
+++ b/src/main/java/com/takatsuka/web/math/interpreter/Evaluator.java
@@ -8,6 +8,7 @@ import com.takatsuka.web.math.evaluators.BasicEvaluator;
 import com.takatsuka.web.math.evaluators.ExponentialEvaluator;
 import com.takatsuka.web.math.evaluators.RandomEvaluator;
 import com.takatsuka.web.math.evaluators.TrigEvaluator;
+import com.takatsuka.web.utils.exceptions.MathExecException;
 import org.slf4j.Logger;
 
 import java.lang.reflect.InvocationTargetException;
@@ -18,7 +19,6 @@ import java.math.MathContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeoutException;
 
 public class Evaluator {
   private static final Logger logger = MathLogger.forCallingClass();
@@ -65,8 +65,15 @@ public class Evaluator {
         return String.valueOf(
             new BigDecimal(args.get(0)).multiply(new BigDecimal(args.get(1)), mathContext));
       case DIVIDE:
-        return String.valueOf(
-            new BigDecimal(args.get(0)).divide(new BigDecimal(args.get(1)), mathContext));
+        BigDecimal param1 = new BigDecimal(args.get(0));
+        BigDecimal param2 = new BigDecimal(args.get(1));
+        if (param2.equals(BigDecimal.ZERO)) {
+          throw new MathExecException(
+              String.format("%s / %s", param1.toString(), param2.toString()),
+              0,
+              MathExecException.MathExecExceptionType.DIV_BY_ZERO);
+        }
+        return String.valueOf(param1.divide(param2, mathContext));
       case MOD:
         return String.valueOf(new BigInteger(args.get(0)).mod(new BigInteger(args.get(1))));
       case POWER:

--- a/src/main/java/com/takatsuka/web/math/interpreter/FunctionMapper.java
+++ b/src/main/java/com/takatsuka/web/math/interpreter/FunctionMapper.java
@@ -3,7 +3,7 @@ package com.takatsuka.web.math.interpreter;
 import com.takatsuka.web.interpreter.Function;
 import com.takatsuka.web.interpreter.FunctionDefinition;
 import com.takatsuka.web.interpreter.ParamType;
-import org.springframework.stereotype.Component;
+import com.takatsuka.web.utils.exceptions.MathParseException;
 
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
 public class FunctionMapper {
   private static final String SYMBOL_GROUPS = "([+\\-*/%^!()])";
   private static final String NUM_REGEX = "(-?\\d+([.]\\d+)?)";
+  private static final String FUNC_REGEX = "(\\w+)";
 
   private final Map<String, Function> multiVariableFunctionMap;
   private final Map<String, Function> symbolOperatorMap;
@@ -34,22 +35,23 @@ public class FunctionMapper {
     functionToMethodMap = new HashMap<>();
     functionToParamTypeMap = new HashMap<>();
     ArrayList<String> patterns = new ArrayList<>();
-    patterns.add("//");   // Add integer division as so it is not parsed as two '/'
+    patterns.add("//"); // Add integer division as so it is not parsed as two '/'
     patterns.add(NUM_REGEX);
     patterns.add(SYMBOL_GROUPS);
+    patterns.add(FUNC_REGEX);
     patterns.add(",");
 
     // Build multi-variable functions
     for (FunctionDefinition functionDefinition : functionsList) {
       // Map the symbol to the function
       multiVariableFunctionMap.put(
-          functionDefinition.getSymbol(), functionDefinition.getFunction());
+          functionDefinition.getSymbol().toLowerCase(), functionDefinition.getFunction());
 
       // Map the function to max-args.
       functionToMaxArgMap.put(functionDefinition.getFunction(), functionDefinition.getMaxArgs());
 
       // Add pattern
-      patterns.add(functionDefinition.getPattern());
+      //      patterns.add(functionDefinition.getPattern());
 
       // Add function value
       functionToMethodMap.put(functionDefinition.getFunction(), getMethod(functionDefinition));
@@ -88,13 +90,14 @@ public class FunctionMapper {
   }
 
   public Function mapStringToFunction(String token) {
+    token = token.toLowerCase();
     if (multiVariableFunctionMap.containsKey(token)) {
       return multiVariableFunctionMap.get(token);
     }
     if (symbolOperatorMap.containsKey(token)) {
       return symbolOperatorMap.get(token);
     }
-    return null;
+    throw new MathParseException(token, null, MathParseException.ParseExceptionType.FUNCTION_NOT_DEFINED);
   }
 
   public int getMaxArgs(Function function) {

--- a/src/main/java/com/takatsuka/web/math/interpreter/MathParser.java
+++ b/src/main/java/com/takatsuka/web/math/interpreter/MathParser.java
@@ -168,15 +168,12 @@ public class MathParser {
         int idx = Collections.max(expressionTable.keySet());
         ExpressionEntry.Builder entryToUpdate = expressionTable.get(idx).toBuilder();
 
-        if (functionMapper.getMaxArgs(entryToUpdate.getFunction()) == Integer.MAX_VALUE) {
-          // The position is just "the next"
-          entryToUpdate.addArgs(argBackup.remove()); // Get the previous arg
-        } else {
+        if (functionMapper.getMaxArgs(entryToUpdate.getFunction()) != Integer.MAX_VALUE) {
           for (int j = entryToUpdate.getArgsCount(); j < entryToUpdate.getMaxArg() - 1; j++) {
             entryToUpdate.addArgs("0"); // Placeholder
           }
-          entryToUpdate.addArgs(argBackup.remove());
         }
+        entryToUpdate.addArgs(argBackup.remove()); // Get the previous arg
 
         expressionTable.replace(idx, entryToUpdate.build());
       } else {

--- a/src/main/java/com/takatsuka/web/utils/exceptions/MathException.java
+++ b/src/main/java/com/takatsuka/web/utils/exceptions/MathException.java
@@ -1,0 +1,4 @@
+package com.takatsuka.web.utils.exceptions;
+
+public interface MathException {
+}

--- a/src/main/java/com/takatsuka/web/utils/exceptions/MathException.java
+++ b/src/main/java/com/takatsuka/web/utils/exceptions/MathException.java
@@ -1,4 +1,7 @@
 package com.takatsuka.web.utils.exceptions;
 
-public interface MathException {
+public abstract class MathException extends RuntimeException{
+    public String toString() {
+        return "There was an unknown error while executing this statement.";
+    }
 }

--- a/src/main/java/com/takatsuka/web/utils/exceptions/MathExecException.java
+++ b/src/main/java/com/takatsuka/web/utils/exceptions/MathExecException.java
@@ -2,10 +2,10 @@ package com.takatsuka.web.utils.exceptions;
 
 public class MathExecException extends MathException{
   private final String cause;
-  private final int location;
+  private final String location;
   private final MathExecExceptionType mathExecExceptionType;
 
-  public MathExecException(String cause, int location, MathExecExceptionType mathExecExceptionType) {
+  public MathExecException(String cause, String location, MathExecExceptionType mathExecExceptionType) {
     this.cause = cause;
     this.location = location;
     this.mathExecExceptionType = mathExecExceptionType;
@@ -18,6 +18,13 @@ public class MathExecException extends MathException{
       case DIV_BY_ZERO:
         typeMessage = "Cannot divide by zero.";
         break;
+      case FUNCTION_IN_TESTING:
+        typeMessage =
+                String.format("Function '%s' is in testing and not available right now.", cause);
+        break;
+      case POSITIVE_REQUIRED:
+        typeMessage =
+                String.format("A positive value is required in the %s.", cause);
       default:
         typeMessage = "Unknown Execution Failure.";
         break;
@@ -28,5 +35,7 @@ public class MathExecException extends MathException{
 
   public enum MathExecExceptionType {
     DIV_BY_ZERO,
+    FUNCTION_IN_TESTING,
+    POSITIVE_REQUIRED
   }
 }

--- a/src/main/java/com/takatsuka/web/utils/exceptions/MathExecException.java
+++ b/src/main/java/com/takatsuka/web/utils/exceptions/MathExecException.java
@@ -1,6 +1,6 @@
 package com.takatsuka.web.utils.exceptions;
 
-public class MathExecException extends RuntimeException implements MathException{
+public class MathExecException extends MathException{
   private final String cause;
   private final int location;
   private final MathExecExceptionType mathExecExceptionType;
@@ -23,7 +23,7 @@ public class MathExecException extends RuntimeException implements MathException
         break;
     }
 
-    return "MathExecException: " + typeMessage;
+    return typeMessage;
   }
 
   public enum MathExecExceptionType {

--- a/src/main/java/com/takatsuka/web/utils/exceptions/MathExecException.java
+++ b/src/main/java/com/takatsuka/web/utils/exceptions/MathExecException.java
@@ -1,0 +1,32 @@
+package com.takatsuka.web.utils.exceptions;
+
+public class MathExecException extends RuntimeException implements MathException{
+  private final String cause;
+  private final int location;
+  private final MathExecExceptionType mathExecExceptionType;
+
+  public MathExecException(String cause, int location, MathExecExceptionType mathExecExceptionType) {
+    this.cause = cause;
+    this.location = location;
+    this.mathExecExceptionType = mathExecExceptionType;
+  }
+
+  @Override
+  public String toString() {
+    String typeMessage;
+    switch(mathExecExceptionType){
+      case DIV_BY_ZERO:
+        typeMessage = "Cannot divide by zero.";
+        break;
+      default:
+        typeMessage = "Unknown Execution Failure.";
+        break;
+    }
+
+    return "MathExecException: " + typeMessage;
+  }
+
+  public enum MathExecExceptionType {
+    DIV_BY_ZERO,
+  }
+}

--- a/src/main/java/com/takatsuka/web/utils/exceptions/MathExecTimeoutException.java
+++ b/src/main/java/com/takatsuka/web/utils/exceptions/MathExecTimeoutException.java
@@ -1,6 +1,4 @@
 package com.takatsuka.web.utils.exceptions;
 
-import java.util.concurrent.TimeoutException;
-
-public class MathExecTimeoutException extends TimeoutException implements MathException {
+public class MathExecTimeoutException extends MathException {
 }

--- a/src/main/java/com/takatsuka/web/utils/exceptions/MathExecTimeoutException.java
+++ b/src/main/java/com/takatsuka/web/utils/exceptions/MathExecTimeoutException.java
@@ -1,4 +1,0 @@
-package com.takatsuka.web.utils.exceptions;
-
-public class MathExecTimeoutException extends MathException {
-}

--- a/src/main/java/com/takatsuka/web/utils/exceptions/MathExecTimeoutException.java
+++ b/src/main/java/com/takatsuka/web/utils/exceptions/MathExecTimeoutException.java
@@ -1,0 +1,6 @@
+package com.takatsuka.web.utils.exceptions;
+
+import java.util.concurrent.TimeoutException;
+
+public class MathExecTimeoutException extends TimeoutException implements MathException {
+}

--- a/src/main/java/com/takatsuka/web/utils/exceptions/MathParseException.java
+++ b/src/main/java/com/takatsuka/web/utils/exceptions/MathParseException.java
@@ -1,6 +1,6 @@
 package com.takatsuka.web.utils.exceptions;
 
-public class MathParseException extends RuntimeException implements MathException{
+public class MathParseException extends MathException{
   private final String cause;
   private final int location;
   private final ParseExceptionType parseExceptionType;
@@ -25,7 +25,6 @@ public class MathParseException extends RuntimeException implements MathExceptio
         typeMessage = "Unknown.";
         break;
     }
-
 
     return String.format("MathParseException: Caused by: '%s' At: '%d'. %s", cause, location, typeMessage);
   }

--- a/src/main/java/com/takatsuka/web/utils/exceptions/MathParseException.java
+++ b/src/main/java/com/takatsuka/web/utils/exceptions/MathParseException.java
@@ -1,0 +1,37 @@
+package com.takatsuka.web.utils.exceptions;
+
+public class MathParseException extends RuntimeException implements MathException{
+  private final String cause;
+  private final int location;
+  private final ParseExceptionType parseExceptionType;
+
+  private MathParseException(String cause, int location, ParseExceptionType exceptionType) {
+    this.cause = cause;
+    this.location = location;
+    this.parseExceptionType = exceptionType;
+  }
+
+  @Override
+  public String toString() {
+    String typeMessage;
+    switch (parseExceptionType){
+      case FUNCTION_NOT_DEFINED:
+        typeMessage = "Function Not Defined.";
+        break;
+      case FUNCTION_IN_TESTING:
+        typeMessage = "Function In Testing.";
+        break;
+      default:
+        typeMessage = "Unknown.";
+        break;
+    }
+
+
+    return String.format("MathParseException: Caused by: '%s' At: '%d'. %s", cause, location, typeMessage);
+  }
+
+  enum ParseExceptionType {
+    FUNCTION_NOT_DEFINED,
+    FUNCTION_IN_TESTING
+  }
+}

--- a/src/main/java/com/takatsuka/web/utils/exceptions/MathParseException.java
+++ b/src/main/java/com/takatsuka/web/utils/exceptions/MathParseException.java
@@ -1,11 +1,11 @@
 package com.takatsuka.web.utils.exceptions;
 
-public class MathParseException extends MathException{
+public class MathParseException extends MathException {
   private final String cause;
-  private final int location;
+  private final String location;
   private final ParseExceptionType parseExceptionType;
 
-  private MathParseException(String cause, int location, ParseExceptionType exceptionType) {
+  public MathParseException(String cause, String location, ParseExceptionType exceptionType) {
     this.cause = cause;
     this.location = location;
     this.parseExceptionType = exceptionType;
@@ -14,23 +14,19 @@ public class MathParseException extends MathException{
   @Override
   public String toString() {
     String typeMessage;
-    switch (parseExceptionType){
+    switch (parseExceptionType) {
       case FUNCTION_NOT_DEFINED:
-        typeMessage = "Function Not Defined.";
-        break;
-      case FUNCTION_IN_TESTING:
-        typeMessage = "Function In Testing.";
+        typeMessage = String.format("Function '%s' is not defined.", cause);
         break;
       default:
         typeMessage = "Unknown.";
         break;
     }
 
-    return String.format("MathParseException: Caused by: '%s' At: '%d'. %s", cause, location, typeMessage);
+    return typeMessage;
   }
 
-  enum ParseExceptionType {
-    FUNCTION_NOT_DEFINED,
-    FUNCTION_IN_TESTING
+  public enum ParseExceptionType {
+    FUNCTION_NOT_DEFINED
   }
 }

--- a/src/main/resources/functions/exponential/mod_power.json
+++ b/src/main/resources/functions/exponential/mod_power.json
@@ -5,7 +5,7 @@
   "mathMethod": {
     "className": "com.takatsuka.web.math.evaluators.ExponentialEvaluator",
     "methodName": "modPow",
-    "paramTypes": ["BIG_INTEGER", "BIG_INTEGER", "BIG_INTEGER"]
+    "paramTypes": ["BIG_DECIMAL", "BIG_INTEGER", "BIG_INTEGER"]
   },
   "symbol": "modPow",
   "function": "MOD_POWER",


### PR DESCRIPTION
This PR implements the following
1. Error messages which are transmitted to the client
      - Error messages are now created for function not found errors, divide by zero, and positive modulus requirements in mod_pow.
2. Fixed Regex parsing of functions
      - Now, when functions are parsed, only words are parsed. Then, those are matched to the function definitions.
      - This new method allows for better function_not_found error recognition as well as more accurate parsing (e.g. not parsing `logger` to `log`, `er`).

## Issues
- Closes #42 
- Closes #36 