### PR TITLE
Bump Java to 17. Fix Subtraction with new regex

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-            java-version: '11'
+            java-version: '17'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 group = 'com.takatsuka'
 version = '0.0.6'
 description = 'web'
-sourceCompatibility = '11'
+sourceCompatibility = '17'
 
 publishing {
     publications {

--- a/src/main/java/com/takatsuka/web/math/interpreter/FunctionMapper.java
+++ b/src/main/java/com/takatsuka/web/math/interpreter/FunctionMapper.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
 
 public class FunctionMapper {
   private static final String SYMBOL_GROUPS = "([+\\-*/%^!()])";
-  private static final String NUM_REGEX = "(-?\\d+([.]\\d+)?)";
+  private static final String NUM_REGEX = "(((?<=[+\\-*`/%^(]|^)-)?\\d+([.]\\d+)?)";
   private static final String FUNC_REGEX = "(\\w+)";
 
   private final Map<String, Function> multiVariableFunctionMap;

--- a/src/main/java/com/takatsuka/web/math/interpreter/MathParser.java
+++ b/src/main/java/com/takatsuka/web/math/interpreter/MathParser.java
@@ -34,7 +34,7 @@ public class MathParser {
   }
 
   public String evaluate(String expression) {
-    ArrayList<String> tokens = tokenize(expression);
+    ArrayList<String> tokens = tokenize(expression.replaceAll("[\\n\\r\\s]+", ""));
     return evaluate(tokens);
   }
 
@@ -55,6 +55,7 @@ public class MathParser {
       tokens.add(tok);
     }
 
+    System.out.println(tokens);
     logger.debug("Expression '{}' successfully tokenized to '{}'", expression, tokens.toString());
 
     return tokens;
@@ -120,22 +121,12 @@ public class MathParser {
           funcId += 1;
           int level;
           Function function = functionMapper.mapStringToFunction(token);
-          switch (Objects.requireNonNull(function)) {
-            case ADD:
-            case SUBTRACT:
-              level = 1;
-              break;
-            case MULTIPLY:
-            case DIVIDE:
-              level = 2;
-              break;
-            case POWER:
-              level = 3;
-              break;
-            default:
-              level = 10;
-              break;
-          }
+          level = switch (Objects.requireNonNull(function)) {
+            case ADD, SUBTRACT -> 1;
+            case MULTIPLY, DIVIDE -> 2;
+            case POWER -> 3;
+            default -> 10;
+          };
 
           ExpressionEntry.Builder expressionBuilder = ExpressionEntry.newBuilder();
           expressionBuilder


### PR DESCRIPTION
Closes #47 

This PR fixes the problems with the formatting of subtraction problems.

Previously, `1-1` would be parsed to `[1, -1]`, but `1 - 1` is properly parsed to `[1, -, 1]`.
This PR expands the number regex to only check for a `-` prefix on numbers where it makes sense. This is, after a 2 variable operator like `+` or `*`, or at the start of a expression like `-1` or `func(-1)`.