### PR TITLE
Add Version Endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 }
 
 group = 'com.takatsuka'
-version = '0.0.6'
+version = '0.0.7'
 description = 'web'
 sourceCompatibility = '11'
 
@@ -51,6 +51,9 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
+springBoot {
+    buildInfo()
+}
 
 sourceSets {
     main {
@@ -60,7 +63,6 @@ sourceSets {
         }
     }
 }
-
 
 protobuf {
     protoc {

--- a/src/main/java/com/takatsuka/web/HomeController.java
+++ b/src/main/java/com/takatsuka/web/HomeController.java
@@ -1,5 +1,7 @@
 package com.takatsuka.web;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -7,8 +9,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @CrossOrigin
 public class HomeController {
+    @Autowired
+    BuildProperties buildProperties;
+
     @GetMapping("/isUp")
     public String isUp() {
         return "Yes!";
+    }
+
+    @GetMapping("/version")
+    public String version() {
+        return buildProperties.getVersion();
     }
 }


### PR DESCRIPTION
Closes #33 

This PR adds an endpoint that emanates the current build version from the `build.gradle` file. From now on, the `build.gradle` file should have its version bumped with each new PR.